### PR TITLE
Remove semantic versioning causing breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "angular": "^1.5.0-beta.0",
-    "autonumeric": "^1.9.45",
+    "autonumeric": "1.9.45",
     "jquery": "^2.1.4"
   }
 }


### PR DESCRIPTION
Hello,

Thanks for creating this npm, it definitely is a slick tool to help with amount currency fields. However my team noticed an issue with more recent versions of autonumeric that was causing runtime errors. This PR simply removes semantic versioning for autonumeric to protect against breaking changes in the dependency.